### PR TITLE
Replaced fixed paths to artifacts

### DIFF
--- a/src/Vega.jl
+++ b/src/Vega.jl
@@ -22,8 +22,12 @@ export @vg_str, @vgplot, vgplot, @vgfrag, vgfrag
 export load, save
 export deletedata, deletedata!
 
-const vegalite_app_path = artifact"vegalite_app"
-const vegalite_app_includes_canvas = ispath(joinpath(vegalite_app_path, "node_modules", "canvas"))
+vegalite_app_path(args...) = joinpath(artifact"vegalite_app", args...)
+const vegalite_app_includes_canvas = Ref{Bool}()
+
+function __init__()
+    vegalite_app_includes_canvas[] = ispath(vegalite_app_path("node_modules", "canvas"))
+end
 
 ########################  settings functions  ############################
 

--- a/src/rendering/render.jl
+++ b/src/rendering/render.jl
@@ -5,10 +5,17 @@
 ######################################################################
 using JSON
 
-asset(url...) = normpath(joinpath(vegalite_app_path, "minified", url...))
+asset(url...) = normpath(vegalite_app_path("minified", url...))
 
-package_json = JSON.parsefile(joinpath(vegalite_app_path, "package.json"))
-version(package) = package_json["dependencies"][package]
+const package_json = Ref{Dict{String, Any}}()
+
+function version(package)
+  if !isassigned(package_json)
+    package_json[] = JSON.parsefile(vegalite_app_path("package.json"))
+  end
+
+  return package_json[]["dependencies"][package]
+end
 
 # Vega Scaffold: https://github.com/vega/vega/wiki/Runtime
 

--- a/src/rendering/show.jl
+++ b/src/rendering/show.jl
@@ -13,8 +13,8 @@ function Base.show(io::IO, v::AbstractVegaSpec)
 end
 
 function convert_vg_to_x(v::VGSpec, script)
-    full_script_path = joinpath(vegalite_app_path, "node_modules", "vega-cli", "bin", script)
-    p = open(Cmd(`$(nodejs_cmd()) $full_script_path -l error`, dir=vegalite_app_path), "r+")
+    full_script_path = vegalite_app_path("node_modules", "vega-cli", "bin", script)
+    p = open(Cmd(`$(nodejs_cmd()) $full_script_path -l error`, dir=vegalite_app_path()), "r+")
     writer = @async begin
         our_json_print(p, v)
         close(p.in)
@@ -29,8 +29,8 @@ function convert_vg_to_x(v::VGSpec, script)
 end
 
 function convert_vg_to_svg(v::VGSpec)
-    vg2svg_script_path = joinpath(vegalite_app_path, "vg2svg.js")
-    p = open(Cmd(`$(nodejs_cmd()) $vg2svg_script_path`, dir=vegalite_app_path), "r+")
+    vg2svg_script_path = vegalite_app_path("vg2svg.js")
+    p = open(Cmd(`$(nodejs_cmd()) $vg2svg_script_path`, dir=vegalite_app_path()), "r+")
     writer = @async begin
         our_json_print(p, v)
         close(p.in)
@@ -55,7 +55,7 @@ function Base.show(io::IO, m::MIME"image/svg+xml", v::VGSpec)
 end
 
 function Base.show(io::IO, m::MIME"application/pdf", v::VGSpec)
-    if vegalite_app_includes_canvas
+    if vegalite_app_includes_canvas[]
         print(io, convert_vg_to_x(v, "vg2pdf"))
     else
         error("Not yet implemented.")
@@ -90,7 +90,7 @@ end
 # end
 
 function Base.show(io::IO, m::MIME"image/png", v::VGSpec)
-    if vegalite_app_includes_canvas
+    if vegalite_app_includes_canvas[]
         print(io, convert_vg_to_x(v, "vg2png"))
     else
         error("Not yet implemented.")


### PR DESCRIPTION
Mirroring https://github.com/queryverse/VegaLite.jl/pull/399.

One point though, now we have two pieces of identical code in two packages, which include:
- `vegalite_app_path`
- `vegalite_app_includes_canvas`
- `asset(url...)`
- `const package_json = Ref{Dict{String, Any}}()`
- `function version(package)`

Given that VegaLite has Vega as a dependency, can we just import those from Vega? The only reason I see why this can be a bad idea is if in the definition `vegalite_app_path(args...) = joinpath(artifact"vegalite_app", args...)`, the `artifact"vegalite_app"` part would reference different artifact version in each package. But I don't know how the artifact system works and if the `artifact` macro takes care of this. And I expect that artifacts always have the same versions for these two packages anyways, right?